### PR TITLE
feat: add Chicago to world clock cities

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -4,6 +4,7 @@
 
 export const CITIES = [
   { name: 'New York',    country: 'United States',  tz: 'America/New_York'    },
+  { name: 'Chicago',     country: 'United States',  tz: 'America/Chicago'     },
   { name: 'London',      country: 'United Kingdom', tz: 'Europe/London'       },
   { name: 'Dubai',       country: 'UAE',            tz: 'Asia/Dubai'          },
   { name: 'Mumbai',      country: 'India',          tz: 'Asia/Kolkata'        },

--- a/tests/clock.test.js
+++ b/tests/clock.test.js
@@ -32,8 +32,8 @@ describe('clock logic', () => {
     expect(tokyoAbbr).toMatch(/JST|GMT\+9/);
   });
 
-  it('should have 6 cities defined', () => {
-    expect(CITIES).toHaveLength(6);
+  it('should have 7 cities defined', () => {
+    expect(CITIES).toHaveLength(7);
   });
 
   describe('getHandAngles', () => {


### PR DESCRIPTION
## Summary
- Adds Chicago (America/Chicago timezone) to the world clock display
- Positioned after New York for geographic grouping of US cities
- Updates test expectation from 6 to 7 cities

## Test plan
- [x] All 11 existing tests pass (`npm test`)
- [ ] Verify Chicago clock card renders correctly in browser
- [ ] Confirm timezone abbreviation shows CDT/CST appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)